### PR TITLE
Bump Caddy to 1.0.3 and improve build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,56 +4,24 @@
 FROM golang:1.12-alpine as build
 
 # args
-ARG version="1.0.2"
+ARG version="1.0.3"
 # add plugin import paths here separated by commas
 ARG plugins=""
 ARG telemetry="true"
 
-# deps
-RUN apk add --no-cache git
-
 # build root
-RUN mkdir /build
 WORKDIR /build
-ENV GO111MODULE=on
-ENV CGO_ENABLED=0
 
 # plugins
-COPY go.mod plugger.go ./
-RUN go run plugger.go -plugins="${plugins}" -telemetry="${telemetry}"
+COPY plugger.go ./
 
-# build
-RUN go build
-RUN mv caddy /
-
-
-#
-# Compress Caddy with upx
-#
-FROM debian:stable as compress
-
-ARG upx_version="3.94"
-
-# dependencies
-RUN apt-get update && apt install -y --no-install-recommends \
-    tar \
-    xz-utils \
-    curl \
-    ca-certificates
-
-# get official upx binary
-RUN curl --silent --show-error --fail --location -o - \
-    "https://github.com/upx/upx/releases/download/v${upx_version}/upx-${upx_version}-amd64_linux.tar.xz" \
-    | tar --no-same-owner -C /usr/bin/ -xJ \
-    --strip-components 1 upx-${upx_version}-amd64_linux/upx
-
-# copy and compress
-COPY --from=build /caddy /usr/bin/caddy
-RUN /usr/bin/upx --ultra-brute /usr/bin/caddy
-
-# test
-RUN /usr/bin/caddy -version
-
+# build & test
+RUN apk add --no-cache git upx ca-certificates \
+    && echo -e "module caddy\nrequire github.com/caddyserver/caddy v${version}" > go.mod \
+    && go run plugger.go -plugins="${plugins}" -telemetry="${telemetry}" \
+    && CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build \
+    && upx --ultra-brute caddy \
+    && ./caddy -version
 
 #
 # Final image
@@ -66,8 +34,8 @@ LABEL org.label-schema.version=${version}
 LABEL org.label-schema.schema-version="1.0"
 
 # copy binary and ca certs
-COPY --from=compress /usr/bin/caddy /bin/caddy
-COPY --from=compress /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /build/caddy /bin/caddy
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # copy default caddyfile
 COPY Caddyfile /etc/Caddyfile

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module caddy
-
-require github.com/caddyserver/caddy v1.0.2


### PR DESCRIPTION
Please see details of PR below

- Create go.mod dynamically based on version argument in Dockerfile
- Remove intermediate Debian build since UPX and ca-certificates are available in alpine distro
